### PR TITLE
SED-6183 Message coming into SEDNA silently hangs the task workers for hours

### DIFF
--- a/lib/html_parser/index.js
+++ b/lib/html_parser/index.js
@@ -24,28 +24,28 @@ function parse(htmlInput, prefix, postfix, sanitizerLogger, messageDir, cb) {
   async.waterfall([
     // remove invalid pcdata, ie) <![if mso ...]>
     function(cb) {
-      sanitizerLogger && sanitizerLogger.info(`MessageDir: ${messageDir} HTML Parser: Remove invalid pcdata`);
+      sanitizerLogger(`MessageDir: ${messageDir} HTML Parser: Remove invalid pcdata`);
       pcdataValidator.filter(htmlInput, cb);
     },
     // sanitize - caja sanitizes, tag balances, and converts html entities
     function(pcdataValidated, cb) {
-      sanitizerLogger && sanitizerLogger.info(`MessageDir: ${messageDir} HTML Parser: google caja sanitizer`);
+      sanitizerLogger(`MessageDir: ${messageDir} HTML Parser: google caja sanitizer`);
       sanitizer.sanitize(pcdataValidated, cb);
     },
     // remove all tags that are not on the tags whitelist
     function(sanitizedHtml, cb) {
-      sanitizerLogger && sanitizerLogger.info(`MessageDir: ${messageDir} HTML Parser: remove all tags that are not on the tags whitelist`);
+      sanitizerLogger(`MessageDir: ${messageDir} HTML Parser: remove all tags that are not on the tags whitelist`);
       tagValidator.validate(sanitizedHtml, cb);
     },
     // remove all tags that are not on the attributes whitelist
     function(tagValidatedHtml, cb) {
-      sanitizerLogger && sanitizerLogger.info(`MessageDir: ${messageDir} HTML Parser: remove all tags that are not on the attributes whitelist`);
+      sanitizerLogger(`MessageDir: ${messageDir} HTML Parser: remove all tags that are not on the attributes whitelist`);
       attributeValidator.validate(tagValidatedHtml, cb);
     },
     // namespace id and class attributes
     function(attributeSanitizedHtml, cb) {
       if (typeof prefix !== 'undefined' || typeof postfix !== 'undefined') {
-        sanitizerLogger && sanitizerLogger.info(`MessageDir: ${messageDir} "HTML Parser: add namespace`);
+        sanitizerLogger(`MessageDir: ${messageDir} "HTML Parser: add namespace`);
         namespacer.namespace(attributeSanitizedHtml, prefix, postfix, cb);
       } else {
         cb(null, attributeSanitizedHtml);
@@ -58,22 +58,22 @@ function parsePurified(htmlInput, prefix, postfix, deSanitizerLogger, messageDir
   async.waterfall([
     // remove invalid pcdata, ie) <![if mso ...]>
     function(cb) {
-      deSanitizerLogger && deSanitizerLogger.info(`MessageDir: ${messageDir} HTML Parser: Remove invalid pcdata`);
+      deSanitizerLogger(`MessageDir: ${messageDir} HTML Parser: Remove invalid pcdata`);
       pcdataValidator.filter(htmlInput, cb);
     },
     // sanitize - caja sanitizes, tag balances, and converts html entities
     function(pcdataValidated, cb) {
-      deSanitizerLogger && deSanitizerLogger.info(`MessageDir: ${messageDir} HTML Parser: google caja sanitizer`);
+      deSanitizerLogger(`MessageDir: ${messageDir} HTML Parser: google caja sanitizer`);
       sanitizer.sanitize(pcdataValidated, cb);
     },
     // remove all tags that are not on the tags whitelist
     function(sanitizedHtml, cb) {
-      deSanitizerLogger && deSanitizerLogger.info(`MessageDir: ${messageDir} HTML Parser: remove all tags that are not on the tags whitelist`);
+      deSanitizerLogger(`MessageDir: ${messageDir} HTML Parser: remove all tags that are not on the tags whitelist`);
       tagValidator.validate(sanitizedHtml, cb);
     },
     // remove all tags that are not on the attributes whitelist
     function(tagValidatedHtml, cb) {
-      deSanitizerLogger && deSanitizerLogger.info(`MessageDir: ${messageDir} HTML Parser: remove all tags that are not on the attributes whitelist`);
+      deSanitizerLogger(`MessageDir: ${messageDir} HTML Parser: remove all tags that are not on the attributes whitelist`);
       attributeValidator.validate(tagValidatedHtml, cb);
     },
     function(attributeSanitizedHtml, cb) {
@@ -83,7 +83,7 @@ function parsePurified(htmlInput, prefix, postfix, deSanitizerLogger, messageDir
         async.whilst(function() {
           return isReplaced;
         }, function(cb) {
-          deSanitizerLogger && deSanitizerLogger.info(`MessageDir: ${messageDir} HTML Parser: strip namespace`);
+          deSanitizerLogger(`MessageDir: ${messageDir} HTML Parser: strip namespace`);
           namespacer.stripNamespace(attributeSanitizedHtml, prefix, postfix, function(err, revertedHtml, replaced) {
             attributeSanitizedHtml = revertedHtml;
             isReplaced = replaced;

--- a/lib/index.js
+++ b/lib/index.js
@@ -24,19 +24,18 @@ function purify(htmlInput, options, cb) {
   var prefix = options.prefix;
   var postfix = options.postfix;
   const messageDir = options.messageDir;
-  const sanitizerLogger = options.logger ? options.logger.get('sanitizer') : null;
-
+  const sanitizerLogger = options.logger ? options.logger.get('sanitizer').info : () => {};
 
   async.parallel([
     // purify style tag contents
     function(cb) {
       const stylePostfix = options.postfix === undefined ? undefined : '.' + options.postfix;
-      sanitizerLogger && sanitizerLogger.info(`MessageDir: ${messageDir} Style parsing started`);
+      sanitizerLogger(`MessageDir: ${messageDir} Style parsing started`);
       styleParser.parse(htmlInput, prefix, stylePostfix, sanitizerLogger, messageDir, cb);
     },
     // purify html body contents
     function(cb) {
-      sanitizerLogger && sanitizerLogger.info(`MessageDir: ${messageDir} HTML parsing started`);
+      sanitizerLogger(`MessageDir: ${messageDir} HTML parsing started`);
       htmlParser.parse(htmlInput, prefix, postfix, sanitizerLogger, messageDir, cb);
     },
   ], function(err, results) {
@@ -61,16 +60,16 @@ function revertNamespace(htmlInput, options, cb) {
   var prefix = options.prefix;
   var postfix = options.postfix;
   const messageDir = options.messageDir;
-  const deSanitizerLogger = options.logger ? options.logger.get('de_sanitizer') : null;
+  const deSanitizerLogger = options.logger ? options.logger.get('de_sanitizer').info : () => {};
   async.parallel([
     // purify style tag contents
     function(cb) {
-      deSanitizerLogger && deSanitizerLogger.info(`MessageDir: ${messageDir} Style parsing started`);
+      deSanitizerLogger(`MessageDir: ${messageDir} Style parsing started`);
       styleParser.parsePurified(htmlInput, prefix, '.' + postfix, deSanitizerLogger, messageDir, cb);
     },
     // purify html body contents
     function(cb) {
-      deSanitizerLogger && deSanitizerLogger.info(`MessageDir: ${messageDir} HTML parsing started`);
+      deSanitizerLogger(`MessageDir: ${messageDir} HTML parsing started`);
       htmlParser.parsePurified(htmlInput, prefix, postfix, deSanitizerLogger, messageDir, cb);
     },
   ], function(err, results) {

--- a/lib/style_parser/index.js
+++ b/lib/style_parser/index.js
@@ -20,17 +20,17 @@ function parse(cssInput, prefix, postfix, sanitizerLogger, messageDir, cb) {
   async.waterfall([
     // remove everything except style tag contents
     function(cb) {
-      sanitizerLogger && sanitizerLogger.info(`MessageDir: ${messageDir} StyleParser: remove everything except style tag contents`);
+      sanitizerLogger(`MessageDir: ${messageDir} StyleParser: remove everything except style tag contents`);
       sanitizer.sanitize(cssInput, cb);
     },
     // namespace sanitized style tag contents
     function(sanitizedHtml, cb) {
-      sanitizerLogger && sanitizerLogger.info(`MessageDir: ${messageDir} StyleParser: add namespace`);
+      sanitizerLogger(`MessageDir: ${messageDir} StyleParser: add namespace`);
       namespacer.namespace(sanitizedHtml, prefix, postfix, sanitizerLogger, messageDir, cb);
     },
     // add style tags
     function(nameSpacedHtml, cb) {
-      sanitizerLogger && sanitizerLogger.info(`MessageDir: ${messageDir} StyleParser: add style tags`);
+      sanitizerLogger(`MessageDir: ${messageDir} StyleParser: add style tags`);
       nameSpacedHtml = addStyleTags(nameSpacedHtml);
       cb(null, nameSpacedHtml);
     }
@@ -49,15 +49,15 @@ function parsePurified(cssInput, prefix, postfix, deSanitizerLogger, messageDir,
   async.waterfall([
     // remove everything except style tag contents
     function(cb) {
-      deSanitizerLogger && deSanitizerLogger.info(`MessageDir: ${messageDir} StyleParser: remove everything except style tag contents`);
+      deSanitizerLogger(`MessageDir: ${messageDir} StyleParser: remove everything except style tag contents`);
       sanitizer.sanitize(cssInput, cb);
     },
     // strip namespace
     function(sanitizedHtml, cb) {
-      deSanitizerLogger && deSanitizerLogger.info(`MessageDir: ${messageDir} StyleParser: strip namespace`);
+      deSanitizerLogger(`MessageDir: ${messageDir} StyleParser: strip namespace`);
       if ((typeof prefix !== 'undefined' || typeof postfix !== 'undefined') && sanitizedHtml !== '') {
         namespacer.stripNamespace(sanitizedHtml, prefix, postfix, function(err, stripped) {
-          deSanitizerLogger && deSanitizerLogger.info(`MessageDir: ${messageDir} StyleParser: add style tags`);
+          deSanitizerLogger(`MessageDir: ${messageDir} StyleParser: add style tags`);
           strippedStyles = addStyleTags(stripped);
           cb(null, strippedStyles);
         });

--- a/lib/style_parser/namespacer/index.js
+++ b/lib/style_parser/namespacer/index.js
@@ -19,7 +19,7 @@ function namespace(styles, prefix, postfix, sanitizerLogger, messageDir, cb) {
     // prefix styles
     function(cb) {
       if (prefix) {
-        sanitizerLogger && sanitizerLogger.info(`MessageDir: ${messageDir} StyleParser: Prepend`);
+        sanitizerLogger(`MessageDir: ${messageDir} StyleParser: Prepend`);
         prefixer.prepend(styles, prefix, sanitizerLogger, messageDir, cb);
       } else {
         cb(null, styles);
@@ -28,7 +28,7 @@ function namespace(styles, prefix, postfix, sanitizerLogger, messageDir, cb) {
     // postfix styles
     function(prefixedStyles, cb) {
       if (postfix) {
-        sanitizerLogger && sanitizerLogger.info(`MessageDir: ${messageDir} StyleParser: append`);
+        sanitizerLogger(`MessageDir: ${messageDir} StyleParser: append`);
         postfixer.append(prefixedStyles, postfix, cb);
       } else {
         cb(null, prefixedStyles);

--- a/lib/style_parser/namespacer/index.js
+++ b/lib/style_parser/namespacer/index.js
@@ -20,7 +20,7 @@ function namespace(styles, prefix, postfix, sanitizerLogger, messageDir, cb) {
     function(cb) {
       if (prefix) {
         sanitizerLogger && sanitizerLogger.info(`MessageDir: ${messageDir} StyleParser: Prepend`);
-        prefixer.prepend(styles, prefix, cb);
+        prefixer.prepend(styles, prefix, sanitizerLogger, messageDir, cb);
       } else {
         cb(null, styles);
       }

--- a/lib/style_parser/namespacer/prefixer.js
+++ b/lib/style_parser/namespacer/prefixer.js
@@ -22,15 +22,14 @@ function prepend(styles, prefix, sanitizerLogger, messageDir, cb) {
     if (rule.type !== 'rule') {
       return rule;
     }
-
+    sanitizerLogger && sanitizerLogger.info(`MessageDir: ${messageDir} StyleParser: regex start`);
     rule.selectors = rule.selectors.map(function (selector) {
-      sanitizerLogger && sanitizerLogger.info(`MessageDir: ${messageDir} StyleParser: regex started to prefix`);
       return prefixSelector(selector, prefix);
     });
 
     return rule;
   });
-  sanitizerLogger && sanitizerLogger.info(`MessageDir: ${messageDir} StyleParser: parsing end after regex`);
+  sanitizerLogger && sanitizerLogger.info(`MessageDir: ${messageDir} StyleParser: regex end`);
   cb(null, css.stringify(obj));
 }
 

--- a/lib/style_parser/namespacer/prefixer.js
+++ b/lib/style_parser/namespacer/prefixer.js
@@ -12,15 +12,26 @@ var css = require('css');
  * @cb err, string
  */
 function prepend(styles, prefix, cb) {
-  // clean classes
-  // /(\.|#)  find any period or hash symbol (css id or class symbol)
-  // (-?[_a-z]+[_a-z0-9\-]*)  any valid class or id name
-  // (?=[^}]+\{)/             get everything inside the style block { }
-  // $1 = # or .
-  // $2 = the class name we need to prefix
   var prefixed = styles.replace(/(\.|#)(-?[_a-z]+[_a-z0-9\-]*)(?=[^}]+\{)/ig, '$1' + prefix + '$2');
+  var obj = css.parse(styles);
 
-  cb(null, prefixed);
+  obj.stylesheet.rules = obj.stylesheet.rules.map(function (rule) {
+    if (rule.type !== 'rule') {
+      return rule;
+    }
+
+    rule.selectors = rule.selectors.map(function (selector) {
+      return prefixSelector(selector, prefix);
+    });
+
+    return rule;
+  });
+
+  cb(null, css.stringify(obj));
+}
+
+function prefixSelector(selector, prefix) {
+  return selector.replace(/(\.|#)(-?[_a-z]+[_a-z0-9\-]*)/ig, '$1' + prefix + '$2');
 }
 
 function strip(styles, prefix, cb) {

--- a/lib/style_parser/namespacer/prefixer.js
+++ b/lib/style_parser/namespacer/prefixer.js
@@ -13,13 +13,13 @@ var css = require('css');
  */
 function prepend(styles, prefix, sanitizerLogger, messageDir, cb) {
 
-  sanitizerLogger && sanitizerLogger.info(`MessageDir: ${messageDir} StyleParser: style parsing started using css library`);
+  sanitizerLogger(`MessageDir: ${messageDir} StyleParser: style parsing started using css library`);
   var obj = css.parse(styles, {silent: true});
 
-  sanitizerLogger && sanitizerLogger.info(`MessageDir: ${messageDir} StyleParser: style parsing end using css library`);
+  sanitizerLogger(`MessageDir: ${messageDir} StyleParser: style parsing end using css library`);
 
   if (obj.stylesheet.parsingErrors.length > 0) {
-    sanitizerLogger && sanitizerLogger.info(`MessageDir: ${messageDir} StyleParser: badly formatted style`);
+    sanitizerLogger(`MessageDir: ${messageDir} StyleParser: badly formatted style`);
     return cb(null, styles);
   }
 
@@ -27,15 +27,15 @@ function prepend(styles, prefix, sanitizerLogger, messageDir, cb) {
     if (rule.type !== 'rule') {
       return rule;
     }
-    sanitizerLogger && sanitizerLogger.info(`MessageDir: ${messageDir} StyleParser: regex start`);
+    sanitizerLogger(`MessageDir: ${messageDir} StyleParser: regex start`);
     rule.selectors = rule.selectors.map(function (selector) {
       return prefixSelector(selector, prefix);
     });
 
     return rule;
   });
-  sanitizerLogger && sanitizerLogger.info(`MessageDir: ${messageDir} StyleParser: regex end`);
-  cb(null, css.stringify(obj, {silent: true}));
+  sanitizerLogger(`MessageDir: ${messageDir} StyleParser: regex end`);
+  cb(null, css.stringify(obj, {compress: true}));
 }
 
 function prefixSelector(selector, prefix) {

--- a/lib/style_parser/namespacer/prefixer.js
+++ b/lib/style_parser/namespacer/prefixer.js
@@ -14,9 +14,14 @@ var css = require('css');
 function prepend(styles, prefix, sanitizerLogger, messageDir, cb) {
 
   sanitizerLogger && sanitizerLogger.info(`MessageDir: ${messageDir} StyleParser: style parsing started using css library`);
-  var obj = css.parse(styles);
+  var obj = css.parse(styles, {silent: true});
 
   sanitizerLogger && sanitizerLogger.info(`MessageDir: ${messageDir} StyleParser: style parsing end using css library`);
+
+  if (obj.stylesheet.parsingErrors.length > 0) {
+    sanitizerLogger && sanitizerLogger.info(`MessageDir: ${messageDir} StyleParser: badly formatted style`);
+    return cb(null, styles);
+  }
 
   obj.stylesheet.rules = obj.stylesheet.rules.map(function (rule) {
     if (rule.type !== 'rule') {
@@ -30,7 +35,7 @@ function prepend(styles, prefix, sanitizerLogger, messageDir, cb) {
     return rule;
   });
   sanitizerLogger && sanitizerLogger.info(`MessageDir: ${messageDir} StyleParser: regex end`);
-  cb(null, css.stringify(obj));
+  cb(null, css.stringify(obj, {silent: true}));
 }
 
 function prefixSelector(selector, prefix) {

--- a/lib/style_parser/namespacer/prefixer.js
+++ b/lib/style_parser/namespacer/prefixer.js
@@ -11,9 +11,12 @@ var css = require('css');
  *
  * @cb err, string
  */
-function prepend(styles, prefix, cb) {
-  var prefixed = styles.replace(/(\.|#)(-?[_a-z]+[_a-z0-9\-]*)(?=[^}]+\{)/ig, '$1' + prefix + '$2');
+function prepend(styles, prefix, sanitizerLogger, messageDir, cb) {
+
+  sanitizerLogger && sanitizerLogger.info(`MessageDir: ${messageDir} StyleParser: style parsing started using css library`);
   var obj = css.parse(styles);
+
+  sanitizerLogger && sanitizerLogger.info(`MessageDir: ${messageDir} StyleParser: style parsing end using css library`);
 
   obj.stylesheet.rules = obj.stylesheet.rules.map(function (rule) {
     if (rule.type !== 'rule') {
@@ -21,17 +24,18 @@ function prepend(styles, prefix, cb) {
     }
 
     rule.selectors = rule.selectors.map(function (selector) {
+      sanitizerLogger && sanitizerLogger.info(`MessageDir: ${messageDir} StyleParser: regex started to prefix`);
       return prefixSelector(selector, prefix);
     });
 
     return rule;
   });
-
+  sanitizerLogger && sanitizerLogger.info(`MessageDir: ${messageDir} StyleParser: parsing end after regex`);
   cb(null, css.stringify(obj));
 }
 
 function prefixSelector(selector, prefix) {
-  return selector.replace(/(\.|#)(-?[_a-z]+[_a-z0-9\-]*)/ig, '$1' + prefix + '$2');
+  return selector.replace(/(\.|#)(-?[_a-z][_a-z0-9\-]*)/ig, '$1' + prefix + '$2');
 }
 
 function strip(styles, prefix, cb) {

--- a/test/html_parser/index.js
+++ b/test/html_parser/index.js
@@ -25,7 +25,7 @@ describe('library - html purifier - html parser - parsePurified', function() {
     var dirty = '<span class="ugc ugc-ugc ugc-ugc-moz-cite-prefix ugc-test ugc">my string</span>';
     var expected = '<span class="moz-cite-prefix test">my string</span>';
 
-    parser.parsePurified(dirty, PREFIX, POSTFIX, null, messageId, function(err, namespaced) {
+    parser.parsePurified(dirty, PREFIX, POSTFIX, () => {}, messageId, function(err, namespaced) {
       expect(namespaced).to.be.equal(expected);
       done();
     });
@@ -36,7 +36,7 @@ describe('library - html purifier - html parser - parsePurified', function() {
     var dirty = '<span class="ugc ugc-ugc ugc-ugc-moz-cite-prefix ugc-test ugc">my string has ugc</span>';
     var expected = '<span class="moz-cite-prefix test">my string has ugc</span>';
 
-    parser.parsePurified(dirty, PREFIX, POSTFIX, null, messageId, function(err, namespaced) {
+    parser.parsePurified(dirty, PREFIX, POSTFIX, () => {}, messageId, function(err, namespaced) {
       expect(namespaced).to.be.equal(expected);
       done();
     });
@@ -48,7 +48,7 @@ describe('library - html purifier - html parser - parsePurified', function() {
     var dirty = '<span class="ugc ugc-ugc ugc-ugc ugc ugc">my string has ugc</span>';
     var expected = '<span>my string has ugc</span>';
 
-    parser.parsePurified(dirty, PREFIX, POSTFIX, null, messageId, function(err, namespaced) {
+    parser.parsePurified(dirty, PREFIX, POSTFIX, () => {}, messageId, function(err, namespaced) {
       expect(namespaced).to.be.equal(expected);
       done();
     });
@@ -61,7 +61,7 @@ describe('library - html purifier - html parser - parsePurified', function() {
 
       var expected = '<p class="moz-cite-prefix MsoNormal">Text</p>';
 
-      parser.parsePurified(clean, PREFIX, POSTFIX, null, messageId, function(err, stripped) {
+      parser.parsePurified(clean, PREFIX, POSTFIX, () => {}, messageId, function(err, stripped) {
         expect(stripped).to.equal(expected);
         done();
       });

--- a/test/style_parser/index.js
+++ b/test/style_parser/index.js
@@ -24,7 +24,7 @@ describe('library - html purifier - style parser', function() {
         "#ugc-link, #ugc-link2 #ugc-link3 #ugc-link4 #ugc-link5, p#ugc-test { margin-top:0; }" +
         "</style>";
 
-      styleParser.parsePurified(clean, PREFIX, POSTFIX, null, messageId, function(err, stripped) {
+      styleParser.parsePurified(clean, PREFIX, POSTFIX, () => {}, messageId, function(err, stripped) {
         expect(stripped).to.equal(expected);
         done();
       });
@@ -34,7 +34,7 @@ describe('library - html purifier - style parser', function() {
       var expected = '<style>.first.second.third {\n  margin-top: 0;\n}</style>';
       var clean = '<style>.ugc-first.ugc-second.ugc-third {margin-top: 0;}</style>';
 
-      styleParser.parsePurified(clean, PREFIX, POSTFIX, null, messageId, function(err, stripped) {
+      styleParser.parsePurified(clean, PREFIX, POSTFIX, () => {}, messageId, function(err, stripped) {
         expect(stripped).to.equal(expected);
         done();
       });
@@ -44,7 +44,7 @@ describe('library - html purifier - style parser', function() {
       var expected = '<style>p.orig,\ndiv.test .link {\n  margin-top: 0;\n}</style>';
       var clean = '<style>p.ugc-orig, div.ugc-test .ugc-link {margin-top: 0;}</style>';
 
-      styleParser.parsePurified(clean, PREFIX, POSTFIX, null, messageId, function(err, stripped) {
+      styleParser.parsePurified(clean, PREFIX, POSTFIX, () => {}, messageId, function(err, stripped) {
         expect(stripped).to.equal(expected);
         done();
       });
@@ -54,7 +54,7 @@ describe('library - html purifier - style parser', function() {
       var expected = '<style>#link,\n#link2 #link3 #link4 #link5,\np#test {\n  margin-top: 0;\n}</style>';
       var clean = '<style>#ugc-link, #ugc-link2 #ugc-link3 #ugc-link4 #ugc-link5, p#ugc-test { margin-top: 0; }</style>';
 
-      styleParser.parsePurified(clean, PREFIX, POSTFIX, null, messageId, function(err, stripped) {
+      styleParser.parsePurified(clean, PREFIX, POSTFIX, () => {}, messageId, function(err, stripped) {
         expect(stripped).to.equal(expected);
         done();
       });
@@ -62,7 +62,7 @@ describe('library - html purifier - style parser', function() {
 
     it('should support multiple style tags', function(done) {
       var html = '<style>P.ugc-p5 { margin-left: 1in; }</style><style>P.ugc-p6 { margin-left: 1in; }</style>';
-      styleParser.parsePurified(html, PREFIX, POSTFIX, null, messageId, function(err, res) {
+      styleParser.parsePurified(html, PREFIX, POSTFIX, () => {}, messageId, function(err, res) {
         expect(res).to.equal('<style>P.p5 {\n  margin-left: 1in;\n}\n\nP.p6 {\n  margin-left: 1in;\n}</style>');
         done();
       });

--- a/test/style_parser/namespacer/prefixer.js
+++ b/test/style_parser/namespacer/prefixer.js
@@ -22,9 +22,9 @@ describe('lib - html purifier - style parser - namespacer - prefixer', function(
 
     it('should add the prefix to just a class', function(done) {
       var dirty = '.link {margin-top:0;}';
-      var clean = '.ugc-link {\n  margin-top: 0;\n}';
+      var clean = '.ugc-link{margin-top:0;}';
 
-      prefixer.prepend(dirty, PREFIX, null, messageId, function(err, prefixed) {
+      prefixer.prepend(dirty, PREFIX, () => {}, messageId, function(err, prefixed) {
         expect(prefixed).to.equal(clean);
         done();
       });
@@ -32,9 +32,9 @@ describe('lib - html purifier - style parser - namespacer - prefixer', function(
 
     it('should add the prefix to a tag and class', function(done) {
       var dirty = 'p.orig {margin-top:0;}';
-      var clean = 'p.ugc-orig {\n  margin-top: 0;\n}';
+      var clean = 'p.ugc-orig{margin-top:0;}';
 
-      prefixer.prepend(dirty, PREFIX, null, messageId, function(err, prefixed) {
+      prefixer.prepend(dirty, PREFIX, () => {}, messageId, function(err, prefixed) {
         expect(prefixed).to.equal(clean);
         done();
       });
@@ -42,9 +42,9 @@ describe('lib - html purifier - style parser - namespacer - prefixer', function(
 
     it('should add the prefix with multiple tags', function(done) {
       var dirty = '.first .second .third {margin-top:0;}';
-      var clean = '.ugc-first .ugc-second .ugc-third {\n  margin-top: 0;\n}';
+      var clean = '.ugc-first .ugc-second .ugc-third{margin-top:0;}';
 
-      prefixer.prepend(dirty, PREFIX, null, messageId, function(err, prefixed) {
+      prefixer.prepend(dirty, PREFIX, () => {}, messageId, function(err, prefixed) {
         expect(prefixed).to.equal(clean);
         done();
       });
@@ -52,9 +52,9 @@ describe('lib - html purifier - style parser - namespacer - prefixer', function(
 
     it('should add the prefix with multiple class blocks', function(done) {
       var dirty = 'p.orig, div.test .link {margin-top:0;}';
-      var clean = 'p.ugc-orig,\ndiv.ugc-test .ugc-link {\n  margin-top: 0;\n}';
+      var clean = 'p.ugc-orig,div.ugc-test .ugc-link{margin-top:0;}';
 
-      prefixer.prepend(dirty, PREFIX, null, messageId, function(err, prefixed) {
+      prefixer.prepend(dirty, PREFIX, () => {}, messageId, function(err, prefixed) {
         expect(prefixed).to.equal(clean);
         done();
       });
@@ -62,9 +62,9 @@ describe('lib - html purifier - style parser - namespacer - prefixer', function(
 
     it('should add the prefix to an id', function(done) {
       var dirty = '#orig {margin-top:0;}';
-      var clean = '#ugc-orig {\n  margin-top: 0;\n}';
+      var clean = '#ugc-orig{margin-top:0;}';
 
-      prefixer.prepend(dirty, PREFIX, null, messageId, function(err, prefixed) {
+      prefixer.prepend(dirty, PREFIX, () => {}, messageId, function(err, prefixed) {
         expect(prefixed).to.equal(clean);
         done();
       });
@@ -72,9 +72,9 @@ describe('lib - html purifier - style parser - namespacer - prefixer', function(
 
     it('should add the prefix to id with tag', function(done) {
       var dirty = 'p#orig {margin-top:0;}';
-      var clean = 'p#ugc-orig {\n  margin-top: 0;\n}';
+      var clean = 'p#ugc-orig{margin-top:0;}';
 
-      prefixer.prepend(dirty, PREFIX, null, messageId, function(err, prefixed) {
+      prefixer.prepend(dirty, PREFIX, () => {}, messageId, function(err, prefixed) {
         expect(prefixed).to.equal(clean);
         done();
       });
@@ -82,9 +82,9 @@ describe('lib - html purifier - style parser - namespacer - prefixer', function(
 
     it('should treat id that is a valid tag name as an id name', function(done) {
       var dirty = '#div {margin-top:0;}';
-      var clean = '#ugc-div {\n  margin-top: 0;\n}';
+      var clean = '#ugc-div{margin-top:0;}';
 
-      prefixer.prepend(dirty, PREFIX, null, messageId, function(err, prefixed) {
+      prefixer.prepend(dirty, PREFIX, () => {}, messageId, function(err, prefixed) {
         expect(prefixed).to.equal(clean);
         done();
       });
@@ -92,9 +92,9 @@ describe('lib - html purifier - style parser - namespacer - prefixer', function(
 
     it('should prefix multiple', function(done) {
       var dirty = '#link ,#link2 #link3 #link4 #link5, p#test {margin-top:0;}';
-      var clean = '#ugc-link,\n#ugc-link2 #ugc-link3 #ugc-link4 #ugc-link5,\np#ugc-test {\n  margin-top: 0;\n}';
+      var clean = '#ugc-link,#ugc-link2 #ugc-link3 #ugc-link4 #ugc-link5,p#ugc-test{margin-top:0;}';
 
-      prefixer.prepend(dirty, PREFIX, null, messageId, function(err, prefixed) {
+      prefixer.prepend(dirty, PREFIX, () => {}, messageId, function(err, prefixed) {
         expect(prefixed).to.equal(clean);
         done();
       });
@@ -104,7 +104,7 @@ describe('lib - html purifier - style parser - namespacer - prefixer', function(
       var dirty = '#link ,#link2 #link3 #link4 #link5, p#test }margin-top:0;}';
       var clean = '#link ,#link2 #link3 #link4 #link5, p#test }margin-top:0;}';
 
-      prefixer.prepend(dirty, PREFIX, null, messageId, function(err, prefixed) {
+      prefixer.prepend(dirty, PREFIX, () => {}, messageId, function(err, prefixed) {
         expect(prefixed).to.equal(clean);
         done();
       });

--- a/test/style_parser/namespacer/prefixer.js
+++ b/test/style_parser/namespacer/prefixer.js
@@ -18,12 +18,13 @@ describe('lib - html purifier - style parser - namespacer - prefixer', function(
 
   describe('prefix', function() {
     var PREFIX = 'ugc-';
+    const messageId = "";
 
     it('should add the prefix to just a class', function(done) {
       var dirty = '.link {margin-top:0;}';
-      var clean = '.ugc-link {margin-top:0;}';
+      var clean = '.ugc-link {\n  margin-top: 0;\n}';
 
-      prefixer.prepend(dirty, PREFIX, function(err, prefixed) {
+      prefixer.prepend(dirty, PREFIX, null, messageId, function(err, prefixed) {
         expect(prefixed).to.equal(clean);
         done();
       });
@@ -31,19 +32,19 @@ describe('lib - html purifier - style parser - namespacer - prefixer', function(
 
     it('should add the prefix to a tag and class', function(done) {
       var dirty = 'p.orig {margin-top:0;}';
-      var clean = 'p.ugc-orig {margin-top:0;}';
+      var clean = 'p.ugc-orig {\n  margin-top: 0;\n}';
 
-      prefixer.prepend(dirty, PREFIX, function(err, prefixed) {
+      prefixer.prepend(dirty, PREFIX, null, messageId, function(err, prefixed) {
         expect(prefixed).to.equal(clean);
         done();
       });
     });
 
     it('should add the prefix with multiple tags', function(done) {
-      var dirty = '.first.second.third {margin-top:0;}';
-      var clean = '.ugc-first.ugc-second.ugc-third {margin-top:0;}';
+      var dirty = '.first .second .third {margin-top:0;}';
+      var clean = '.ugc-first .ugc-second .ugc-third {\n  margin-top: 0;\n}';
 
-      prefixer.prepend(dirty, PREFIX, function(err, prefixed) {
+      prefixer.prepend(dirty, PREFIX, null, messageId, function(err, prefixed) {
         expect(prefixed).to.equal(clean);
         done();
       });
@@ -51,9 +52,9 @@ describe('lib - html purifier - style parser - namespacer - prefixer', function(
 
     it('should add the prefix with multiple class blocks', function(done) {
       var dirty = 'p.orig, div.test .link {margin-top:0;}';
-      var clean = 'p.ugc-orig, div.ugc-test .ugc-link {margin-top:0;}';
+      var clean = 'p.ugc-orig,\ndiv.ugc-test .ugc-link {\n  margin-top: 0;\n}';
 
-      prefixer.prepend(dirty, PREFIX, function(err, prefixed) {
+      prefixer.prepend(dirty, PREFIX, null, messageId, function(err, prefixed) {
         expect(prefixed).to.equal(clean);
         done();
       });
@@ -61,9 +62,9 @@ describe('lib - html purifier - style parser - namespacer - prefixer', function(
 
     it('should add the prefix to an id', function(done) {
       var dirty = '#orig {margin-top:0;}';
-      var clean = '#ugc-orig {margin-top:0;}';
+      var clean = '#ugc-orig {\n  margin-top: 0;\n}';
 
-      prefixer.prepend(dirty, PREFIX, function(err, prefixed) {
+      prefixer.prepend(dirty, PREFIX, null, messageId, function(err, prefixed) {
         expect(prefixed).to.equal(clean);
         done();
       });
@@ -71,9 +72,9 @@ describe('lib - html purifier - style parser - namespacer - prefixer', function(
 
     it('should add the prefix to id with tag', function(done) {
       var dirty = 'p#orig {margin-top:0;}';
-      var clean = 'p#ugc-orig {margin-top:0;}';
+      var clean = 'p#ugc-orig {\n  margin-top: 0;\n}';
 
-      prefixer.prepend(dirty, PREFIX, function(err, prefixed) {
+      prefixer.prepend(dirty, PREFIX, null, messageId, function(err, prefixed) {
         expect(prefixed).to.equal(clean);
         done();
       });
@@ -81,9 +82,9 @@ describe('lib - html purifier - style parser - namespacer - prefixer', function(
 
     it('should treat id that is a valid tag name as an id name', function(done) {
       var dirty = '#div {margin-top:0;}';
-      var clean = '#ugc-div {margin-top:0;}';
+      var clean = '#ugc-div {\n  margin-top: 0;\n}';
 
-      prefixer.prepend(dirty, PREFIX, function(err, prefixed) {
+      prefixer.prepend(dirty, PREFIX, null, messageId, function(err, prefixed) {
         expect(prefixed).to.equal(clean);
         done();
       });
@@ -91,9 +92,9 @@ describe('lib - html purifier - style parser - namespacer - prefixer', function(
 
     it('should prefix multiple', function(done) {
       var dirty = '#link ,#link2 #link3 #link4 #link5, p#test {margin-top:0;}';
-      var clean = '#ugc-link ,#ugc-link2 #ugc-link3 #ugc-link4 #ugc-link5, p#ugc-test {margin-top:0;}';
+      var clean = '#ugc-link,\n#ugc-link2 #ugc-link3 #ugc-link4 #ugc-link5,\np#ugc-test {\n  margin-top: 0;\n}';
 
-      prefixer.prepend(dirty, PREFIX, function(err, prefixed) {
+      prefixer.prepend(dirty, PREFIX, null, messageId, function(err, prefixed) {
         expect(prefixed).to.equal(clean);
         done();
       });

--- a/test/style_parser/namespacer/prefixer.js
+++ b/test/style_parser/namespacer/prefixer.js
@@ -99,6 +99,16 @@ describe('lib - html purifier - style parser - namespacer - prefixer', function(
         done();
       });
     });
+
+    it('should ignore badly formatted styles', function(done) {
+      var dirty = '#link ,#link2 #link3 #link4 #link5, p#test }margin-top:0;}';
+      var clean = '#link ,#link2 #link3 #link4 #link5, p#test }margin-top:0;}';
+
+      prefixer.prepend(dirty, PREFIX, null, messageId, function(err, prefixed) {
+        expect(prefixed).to.equal(clean);
+        done();
+      });
+    });
   });
 
   describe('strip', function() {


### PR DESCRIPTION
Use css parser to parse the css , then use regex without the lookahead
Reduces the time taken to sanitize by ~ 3 minutes